### PR TITLE
7437 Fixes

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
     - if: runner.os == 'windows'
       name: Config pagefile (Windows only)
-      uses: al-cheb/configure-pagefile-action@v1.3
+      uses: al-cheb/configure-pagefile-action@v1.4
       with:
         minimum-size: 8GB
         maximum-size: 16GB

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,8 @@ jobs:
   versioning_dev:
     # compute versioning file from python setup.py
     # upload as artifact
-    if: github.repository == 'Project-MONAI/MONAI'
+    # if: github.repository == 'Project-MONAI/MONAI'
+    if: ${{ false }}  # disable docker build job  project-monai/monai#7450
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -47,8 +48,8 @@ jobs:
           rm -rf {*,.[^.]*}
 
   docker_build_dev:
-    # builds projectmonai/monai:latest
-    if: github.repository == 'Project-MONAI/MONAI'
+    # if: github.repository == 'Project-MONAI/MONAI'
+    if: ${{ false }}  # disable docker build job  project-monai/monai#7450
     needs: versioning_dev
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -62,7 +62,7 @@ jobs:
     steps:
     - if: runner.os == 'windows'
       name: Config pagefile (Windows only)
-      uses: al-cheb/configure-pagefile-action@v1.3
+      uses: al-cheb/configure-pagefile-action@v1.4
       with:
         minimum-size: 8GB
         maximum-size: 16GB

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,10 @@ FROM ${PYTORCH_IMAGE}
 
 LABEL maintainer="monai.contact@gmail.com"
 
+# TODO: remark for issue [revise the dockerfile](https://github.com/zarr-developers/numcodecs/issues/431)
+WORKDIR /opt
+RUN git clone --recursive https://github.com/zarr-developers/numcodecs.git && pip wheel numcodecs
+
 WORKDIR /opt/monai
 
 # install full deps

--- a/monai/apps/nnunet/nnunetv2_runner.py
+++ b/monai/apps/nnunet/nnunetv2_runner.py
@@ -37,6 +37,7 @@ class nnUNetV2Runner:  # noqa: N801
     """
     ``nnUNetV2Runner`` provides an interface in MONAI to use `nnU-Net` V2 library to analyze, train, and evaluate
     neural networks for medical image segmentation tasks.
+    A version of nnunetv2 higher than 2.2 is needed for this class.
 
     ``nnUNetV2Runner`` can be used in two ways:
 
@@ -770,7 +771,7 @@ class nnUNetV2Runner:  # noqa: N801
     def predict(
         self,
         list_of_lists_or_source_folder: str | list[list[str]],
-        output_folder: str,
+        output_folder: str | None | list[str],
         model_training_output_dir: str,
         use_folds: tuple[int, ...] | str | None = None,
         tile_step_size: float = 0.5,
@@ -824,7 +825,7 @@ class nnUNetV2Runner:  # noqa: N801
         """
         os.environ["CUDA_VISIBLE_DEVICES"] = f"{gpu_id}"
 
-        from nnunetv2.inference.predict_from_raw_data import predict_from_raw_data
+        from nnunetv2.inference.predict_from_raw_data import nnUNetPredictor
 
         n_processes_preprocessing = (
             self.default_num_processes if num_processes_preprocessing < 0 else num_processes_preprocessing
@@ -832,20 +833,21 @@ class nnUNetV2Runner:  # noqa: N801
         n_processes_segmentation_export = (
             self.default_num_processes if num_processes_segmentation_export < 0 else num_processes_segmentation_export
         )
-
-        predict_from_raw_data(
-            list_of_lists_or_source_folder=list_of_lists_or_source_folder,
-            output_folder=output_folder,
-            model_training_output_dir=model_training_output_dir,
-            use_folds=use_folds,
+        predictor = nnUNetPredictor(
             tile_step_size=tile_step_size,
             use_gaussian=use_gaussian,
             use_mirroring=use_mirroring,
-            perform_everything_on_gpu=perform_everything_on_gpu,
+            perform_everything_on_device=perform_everything_on_gpu,
             verbose=verbose,
+        )
+        predictor.initialize_from_trained_model_folder(
+            model_training_output_dir=model_training_output_dir, use_folds=use_folds, checkpoint_name=checkpoint_name
+        )
+        predictor.predict_from_files(
+            list_of_lists_or_source_folder=list_of_lists_or_source_folder,
+            output_folder_or_list_of_truncated_output_files=output_folder,
             save_probabilities=save_probabilities,
             overwrite=overwrite,
-            checkpoint_name=checkpoint_name,
             num_processes_preprocessing=n_processes_preprocessing,
             num_processes_segmentation_export=n_processes_segmentation_export,
             folder_with_segs_from_prev_stage=folder_with_segs_from_prev_stage,

--- a/monai/auto3dseg/analyzer.py
+++ b/monai/auto3dseg/analyzer.py
@@ -460,7 +460,7 @@ class LabelStats(Analyzer):
         torch.set_grad_enabled(False)
 
         ndas: list[MetaTensor] = [d[self.image_key][i] for i in range(d[self.image_key].shape[0])]  # type: ignore
-        ndas_label: MetaTensor = d[self.label_key].astype(torch.int8)  # (H,W,D)
+        ndas_label: MetaTensor = d[self.label_key].astype(torch.int16)  # (H,W,D)
 
         if ndas_label.shape != ndas[0].shape:
             raise ValueError(f"Label shape {ndas_label.shape} is different from image shape {ndas[0].shape}")
@@ -472,7 +472,7 @@ class LabelStats(Analyzer):
         if isinstance(ndas_label, (MetaTensor, torch.Tensor)):
             unique_label = unique_label.data.cpu().numpy()
 
-        unique_label = unique_label.astype(np.int8).tolist()
+        unique_label = unique_label.astype(np.int16).tolist()
 
         label_substats = []  # each element is one label
         pixel_sum = 0

--- a/monai/metrics/metric.py
+++ b/monai/metrics/metric.py
@@ -37,6 +37,9 @@ class Metric(ABC):
         """
         raise NotImplementedError(f"Subclass {self.__class__.__name__} must implement this method.")
 
+    def __str__(self):
+        return self.__class__.__name__
+
 
 class IterationMetric(Metric):
     """

--- a/monai/transforms/intensity/array.py
+++ b/monai/transforms/intensity/array.py
@@ -91,24 +91,33 @@ class RandGaussianNoise(RandomizableTransform):
         mean: Mean or “centre” of the distribution.
         std: Standard deviation (spread) of distribution.
         dtype: output data type, if None, same as input image. defaults to float32.
+        sample_std: If True, sample the spread of the Gaussian distribution uniformly from 0 to std.
 
     """
 
     backend = [TransformBackends.TORCH, TransformBackends.NUMPY]
 
-    def __init__(self, prob: float = 0.1, mean: float = 0.0, std: float = 0.1, dtype: DtypeLike = np.float32) -> None:
+    def __init__(
+        self,
+        prob: float = 0.1,
+        mean: float = 0.0,
+        std: float = 0.1,
+        dtype: DtypeLike = np.float32,
+        sample_std: bool = True,
+    ) -> None:
         RandomizableTransform.__init__(self, prob)
         self.mean = mean
         self.std = std
         self.dtype = dtype
         self.noise: np.ndarray | None = None
+        self.sample_std = sample_std
 
     def randomize(self, img: NdarrayOrTensor, mean: float | None = None) -> None:
         super().randomize(None)
         if not self._do_transform:
             return None
-        rand_std = self.R.uniform(0, self.std)
-        noise = self.R.normal(self.mean if mean is None else mean, rand_std, size=img.shape)
+        std = self.R.uniform(0, self.std) if self.sample_std else self.std
+        noise = self.R.normal(self.mean if mean is None else mean, std, size=img.shape)
         # noise is float64 array, convert to the output dtype to save memory
         self.noise, *_ = convert_data_type(noise, dtype=self.dtype)
 

--- a/monai/transforms/intensity/dictionary.py
+++ b/monai/transforms/intensity/dictionary.py
@@ -172,7 +172,7 @@ DEFAULT_POST_FIX = PostFix.meta()
 class RandGaussianNoised(RandomizableTransform, MapTransform):
     """
     Dictionary-based version :py:class:`monai.transforms.RandGaussianNoise`.
-    Add Gaussian noise to image. This transform assumes all the expected fields have same shape, if want to add
+    Add Gaussian noise to image. This transform assumes all the expected fields have same shape, if you want to add
     different noise for every field, please use this transform separately.
 
     Args:
@@ -183,6 +183,7 @@ class RandGaussianNoised(RandomizableTransform, MapTransform):
         std: Standard deviation (spread) of distribution.
         dtype: output data type, if None, same as input image. defaults to float32.
         allow_missing_keys: don't raise exception if key is missing.
+        sample_std: If True, sample the spread of the Gaussian distribution uniformly from 0 to std.
     """
 
     backend = RandGaussianNoise.backend
@@ -195,10 +196,11 @@ class RandGaussianNoised(RandomizableTransform, MapTransform):
         std: float = 0.1,
         dtype: DtypeLike = np.float32,
         allow_missing_keys: bool = False,
+        sample_std: bool = True,
     ) -> None:
         MapTransform.__init__(self, keys, allow_missing_keys)
         RandomizableTransform.__init__(self, prob)
-        self.rand_gaussian_noise = RandGaussianNoise(mean=mean, std=std, prob=1.0, dtype=dtype)
+        self.rand_gaussian_noise = RandGaussianNoise(mean=mean, std=std, prob=1.0, dtype=dtype, sample_std=sample_std)
 
     def set_random_state(
         self, seed: int | None = None, state: np.random.RandomState | None = None

--- a/monai/utils/module.py
+++ b/monai/utils/module.py
@@ -209,7 +209,7 @@ def load_submodules(
         if (is_pkg or load_all) and name not in sys.modules and match(exclude_pattern, name) is None:
             try:
                 mod = import_module(name)
-                importer.find_module(name).load_module(name)  # type: ignore
+                importer.find_spec(name).loader.load_module(name)  # type: ignore
                 submodules.append(mod)
             except OptionalImportError:
                 pass  # could not import the optional deps., they are ignored

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,7 +26,7 @@ mypy>=1.5.0
 ninja
 torchvision
 psutil
-cucim>=23.2.0; platform_system == "Linux"
+cucim-cu12; platform_system == "Linux" and python_version >= "3.9" and python_version <= "3.10"
 openslide-python
 imagecodecs; platform_system == "Linux" or platform_system == "Darwin"
 tifffile; platform_system == "Linux" or platform_system == "Darwin"
@@ -46,7 +46,7 @@ pynrrd
 pre-commit
 pydicom
 h5py
-nni; platform_system == "Linux"
+nni; platform_system == "Linux" and "arm" not in platform_machine and "aarch" not in platform_machine
 optuna
 git+https://github.com/Project-MONAI/MetricsReloaded@monai-support#egg=MetricsReloaded
 onnx>=1.13.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ all =
     tqdm>=4.47.0
     lmdb
     psutil
-    cucim>=23.2.0
+    cucim-cu12; python_version >= '3.9' and python_version <= '3.10'
     openslide-python
     tifffile
     imagecodecs
@@ -111,7 +111,7 @@ lmdb =
 psutil =
     psutil
 cucim =
-    cucim>=23.2.0
+    cucim-cu12
 openslide =
     openslide-python
 tifffile =

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -72,6 +72,7 @@ TEST_CASE_1 = [
 
 
 class TestClass:
+
     @staticmethod
     def compute(a, b, func=lambda x, y: x + y):
         return func(a, b)
@@ -126,6 +127,7 @@ TEST_CASE_DUPLICATED_KEY_YAML = [
 
 
 class TestConfigParser(unittest.TestCase):
+
     def test_config_content(self):
         test_config = {"preprocessing": [{"_target_": "LoadImage"}], "dataset": {"_target_": "Dataset"}}
         parser = ConfigParser(config=test_config)

--- a/tests/test_convert_to_onnx.py
+++ b/tests/test_convert_to_onnx.py
@@ -12,6 +12,7 @@
 from __future__ import annotations
 
 import itertools
+import platform
 import unittest
 
 import torch
@@ -28,6 +29,12 @@ else:
     TORCH_DEVICE_OPTIONS = ["cpu"]
 TESTS = list(itertools.product(TORCH_DEVICE_OPTIONS, [True, False], [True, False]))
 TESTS_ORT = list(itertools.product(TORCH_DEVICE_OPTIONS, [True]))
+
+ON_AARCH64 = platform.machine() == "aarch64"
+if ON_AARCH64:
+    rtol, atol = 1e-1, 1e-2
+else:
+    rtol, atol = 1e-3, 1e-4
 
 onnx, _ = optional_import("onnx")
 
@@ -56,8 +63,8 @@ class TestConvertToOnnx(unittest.TestCase):
                 device=device,
                 use_ort=use_ort,
                 use_trace=use_trace,
-                rtol=1e-3,
-                atol=1e-4,
+                rtol=rtol,
+                atol=atol,
             )
         else:
             # https://github.com/pytorch/pytorch/blob/release/1.9/torch/onnx/__init__.py#L182
@@ -72,8 +79,8 @@ class TestConvertToOnnx(unittest.TestCase):
                 device=device,
                 use_ort=use_ort,
                 use_trace=use_trace,
-                rtol=1e-3,
-                atol=1e-4,
+                rtol=rtol,
+                atol=atol,
             )
         self.assertTrue(isinstance(onnx_model, onnx.ModelProto))
 
@@ -107,8 +114,8 @@ class TestConvertToOnnx(unittest.TestCase):
             device=device,
             use_ort=use_ort,
             use_trace=True,
-            rtol=1e-3,
-            atol=1e-4,
+            rtol=rtol,
+            atol=atol,
         )
         self.assertTrue(isinstance(onnx_model, onnx.ModelProto))
 

--- a/tests/test_dynunet.py
+++ b/tests/test_dynunet.py
@@ -11,6 +11,7 @@
 
 from __future__ import annotations
 
+import platform
 import unittest
 from typing import Any, Sequence
 
@@ -23,6 +24,12 @@ from monai.utils import optional_import
 from tests.utils import assert_allclose, skip_if_no_cuda, skip_if_windows, test_script_save
 
 InstanceNorm3dNVFuser, _ = optional_import("apex.normalization", name="InstanceNorm3dNVFuser")
+
+ON_AARCH64 = platform.machine() == "aarch64"
+if ON_AARCH64:
+    rtol, atol = 1e-2, 1e-2
+else:
+    rtol, atol = 1e-4, 1e-4
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -159,7 +166,7 @@ class TestDynUNetWithInstanceNorm3dNVFuser(unittest.TestCase):
                         with eval_mode(net_fuser):
                             result_fuser = net_fuser(input_tensor)
 
-                        assert_allclose(result, result_fuser, rtol=1e-4, atol=1e-4)
+                        assert_allclose(result, result_fuser, rtol=rtol, atol=atol)
 
 
 class TestDynUNetDeepSupervision(unittest.TestCase):

--- a/tests/test_gaussian_filter.py
+++ b/tests/test_gaussian_filter.py
@@ -18,7 +18,7 @@ import torch
 from parameterized import parameterized
 
 from monai.networks.layers import GaussianFilter
-from tests.utils import skip_if_quick
+from tests.utils import SkipIfAtLeastPyTorchVersion, skip_if_quick
 
 TEST_CASES = [[{"type": "erf", "gt": 2.0}], [{"type": "scalespace", "gt": 3.0}], [{"type": "sampled", "gt": 5.0}]]
 TEST_CASES_GPU = [[{"type": "erf", "gt": 0.8, "device": "cuda"}], [{"type": "sampled", "gt": 5.0, "device": "cuda"}]]
@@ -34,6 +34,7 @@ TEST_CASES_SLOW = [
 ]
 
 
+@SkipIfAtLeastPyTorchVersion((2, 2, 0))  # https://github.com/Project-MONAI/MONAI/issues/7445
 class TestGaussianFilterBackprop(unittest.TestCase):
 
     def code_to_run(self, input_args):
@@ -94,6 +95,7 @@ class TestGaussianFilterBackprop(unittest.TestCase):
         self.code_to_run(input_args)
 
 
+@SkipIfAtLeastPyTorchVersion((2, 2, 0))  # https://github.com/Project-MONAI/MONAI/issues/7445
 class GaussianFilterTestCase(unittest.TestCase):
 
     def test_1d(self):

--- a/tests/test_rand_affine.py
+++ b/tests/test_rand_affine.py
@@ -147,7 +147,7 @@ class TestRandAffine(unittest.TestCase):
         g.set_random_state(123)
         result = g(**input_data)
         g.rand_affine_grid.affine = torch.eye(4, dtype=torch.float64)  # reset affine
-        test_resampler_lazy(g, result, input_param, input_data, seed=123)
+        test_resampler_lazy(g, result, input_param, input_data, seed=123, rtol=_rtol)
         if input_param.get("cache_grid", False):
             self.assertTrue(g._cached_grid is not None)
         assert_allclose(result, expected_val, rtol=_rtol, atol=1e-4, type_test="tensor")

--- a/tests/test_rand_affined.py
+++ b/tests/test_rand_affined.py
@@ -234,7 +234,9 @@ class TestRandAffined(unittest.TestCase):
                 lazy_init_param["keys"], lazy_init_param["mode"] = key, mode
                 resampler = RandAffined(**lazy_init_param).set_random_state(123)
                 expected_output = resampler(**call_param)
-                test_resampler_lazy(resampler, expected_output, lazy_init_param, call_param, seed=123, output_key=key)
+                test_resampler_lazy(
+                    resampler, expected_output, lazy_init_param, call_param, seed=123, output_key=key, rtol=_rtol
+                )
             resampler.lazy = False
 
         if input_param.get("cache_grid", False):

--- a/tests/test_rand_gaussian_noised.py
+++ b/tests/test_rand_gaussian_noised.py
@@ -22,8 +22,9 @@ from tests.utils import TEST_NDARRAYS, NumpyImageTestCase2D
 
 TESTS = []
 for p in TEST_NDARRAYS:
-    TESTS.append(["test_zero_mean", p, ["img1", "img2"], 0, 0.1])
-    TESTS.append(["test_non_zero_mean", p, ["img1", "img2"], 1, 0.5])
+    TESTS.append(["test_zero_mean", p, ["img1", "img2"], 0, 0.1, True])
+    TESTS.append(["test_non_zero_mean", p, ["img1", "img2"], 1, 0.5, True])
+    TESTS.append(["test_no_sample_std", p, ["img1", "img2"], 1, 0.5, False])
 
 seed = 0
 
@@ -31,15 +32,18 @@ seed = 0
 class TestRandGaussianNoised(NumpyImageTestCase2D):
 
     @parameterized.expand(TESTS)
-    def test_correct_results(self, _, im_type, keys, mean, std):
-        gaussian_fn = RandGaussianNoised(keys=keys, prob=1.0, mean=mean, std=std, dtype=np.float64)
+    def test_correct_results(self, _, im_type, keys, mean, std, sample_std):
+        gaussian_fn = RandGaussianNoised(
+            keys=keys, prob=1.0, mean=mean, std=std, dtype=np.float64, sample_std=sample_std
+        )
         gaussian_fn.set_random_state(seed)
         im = im_type(self.imt)
         noised = gaussian_fn({k: im for k in keys})
         np.random.seed(seed)
         # simulate the randomize() of transform
         np.random.random()
-        noise = np.random.normal(mean, np.random.uniform(0, std), size=self.imt.shape)
+        _std = np.random.uniform(0, std) if sample_std else std
+        noise = np.random.normal(mean, _std, size=self.imt.shape)
         for k in keys:
             expected = self.imt + noise
             if isinstance(noised[k], torch.Tensor):

--- a/tests/test_resize.py
+++ b/tests/test_resize.py
@@ -46,6 +46,7 @@ diff_t = 0.3 if is_tf32_env() else 0.2
 
 
 class TestResize(NumpyImageTestCase2D):
+
     def test_invalid_inputs(self):
         with self.assertRaises(ValueError):
             resize = Resize(spatial_size=(128, 128, 3), mode="order")

--- a/tests/test_resize.py
+++ b/tests/test_resize.py
@@ -21,7 +21,14 @@ from parameterized import parameterized
 from monai.data import MetaTensor, set_track_meta
 from monai.transforms import Resize
 from tests.lazy_transforms_utils import test_resampler_lazy
-from tests.utils import TEST_NDARRAYS_ALL, NumpyImageTestCase2D, assert_allclose, is_tf32_env, pytorch_after
+from tests.utils import (
+    TEST_NDARRAYS_ALL,
+    NumpyImageTestCase2D,
+    SkipIfAtLeastPyTorchVersion,
+    assert_allclose,
+    is_tf32_env,
+    pytorch_after,
+)
 
 TEST_CASE_0 = [{"spatial_size": 15}, (6, 10, 15)]
 
@@ -39,7 +46,6 @@ diff_t = 0.3 if is_tf32_env() else 0.2
 
 
 class TestResize(NumpyImageTestCase2D):
-
     def test_invalid_inputs(self):
         with self.assertRaises(ValueError):
             resize = Resize(spatial_size=(128, 128, 3), mode="order")
@@ -112,6 +118,7 @@ class TestResize(NumpyImageTestCase2D):
             )
 
     @parameterized.expand([TEST_CASE_0, TEST_CASE_1, TEST_CASE_2, TEST_CASE_2_1, TEST_CASE_3, TEST_CASE_4])
+    @SkipIfAtLeastPyTorchVersion((2, 2, 0))  # https://github.com/Project-MONAI/MONAI/issues/7445
     def test_longest_shape(self, input_param, expected_shape):
         input_data = np.random.randint(0, 2, size=[3, 4, 7, 10])
         input_param["size_mode"] = "longest"

--- a/tests/test_resized.py
+++ b/tests/test_resized.py
@@ -66,6 +66,7 @@ TEST_CORRECT_CASES = [
 
 @SkipIfAtLeastPyTorchVersion((2, 2, 0))  # https://github.com/Project-MONAI/MONAI/issues/7445
 class TestResized(NumpyImageTestCase2D):
+
     def test_invalid_inputs(self):
         with self.assertRaises(ValueError):
             resize = Resized(keys="img", spatial_size=(128, 128, 3), mode="order")

--- a/tests/test_resized.py
+++ b/tests/test_resized.py
@@ -21,7 +21,13 @@ from parameterized import parameterized
 from monai.data import MetaTensor, set_track_meta
 from monai.transforms import Invertd, Resize, Resized
 from tests.lazy_transforms_utils import test_resampler_lazy
-from tests.utils import TEST_NDARRAYS_ALL, NumpyImageTestCase2D, assert_allclose, test_local_inversion
+from tests.utils import (
+    TEST_NDARRAYS_ALL,
+    NumpyImageTestCase2D,
+    SkipIfAtLeastPyTorchVersion,
+    assert_allclose,
+    test_local_inversion,
+)
 
 TEST_CASE_0 = [{"keys": "img", "spatial_size": 15}, (6, 10, 15)]
 
@@ -58,8 +64,8 @@ TEST_CORRECT_CASES = [
 ]
 
 
+@SkipIfAtLeastPyTorchVersion((2, 2, 0))  # https://github.com/Project-MONAI/MONAI/issues/7445
 class TestResized(NumpyImageTestCase2D):
-
     def test_invalid_inputs(self):
         with self.assertRaises(ValueError):
             resize = Resized(keys="img", spatial_size=(128, 128, 3), mode="order")

--- a/tests/test_spatial_resampled.py
+++ b/tests/test_spatial_resampled.py
@@ -11,6 +11,7 @@
 
 from __future__ import annotations
 
+import platform
 import unittest
 
 import numpy as np
@@ -22,6 +23,12 @@ from monai.data.utils import to_affine_nd
 from monai.transforms.spatial.dictionary import SpatialResampled
 from tests.lazy_transforms_utils import test_resampler_lazy
 from tests.utils import TEST_DEVICES, assert_allclose
+
+ON_AARCH64 = platform.machine() == "aarch64"
+if ON_AARCH64:
+    rtol, atol = 1e-1, 1e-2
+else:
+    rtol, atol = 1e-3, 1e-4
 
 TESTS = []
 
@@ -104,7 +111,7 @@ class TestSpatialResample(unittest.TestCase):
 
         # check lazy
         lazy_xform = SpatialResampled(**init_param)
-        test_resampler_lazy(lazy_xform, output_data, init_param, call_param, output_key="img")
+        test_resampler_lazy(lazy_xform, output_data, init_param, call_param, output_key="img", rtol=rtol, atol=atol)
 
         # check inverse
         inverted = xform.inverse(output_data)["img"]


### PR DESCRIPTION
Fixes 7437# .

### Description

Added a default argument to allow the user to specify whether they want the LoadImage Class to continue with one of the default readers if the reader that the user specified is either not installed or is the incorrect version. If the user selects to only use the reader they specified, the LoadImage class will raise an error if the reader the user selected is not installed/wrong version instead of continuing with the available default readers.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ x] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [x ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ x] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
